### PR TITLE
Initialize Next.js skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Rohitha Portfolio Skeleton
+
+This repository contains a starter Next.js project for building the portfolio site originally designed in Canva.
+
+## Project Plan
+
+* **Framework**: [Next.js](https://nextjs.org/) with the App Router and TypeScript.
+* **Styling**: [Tailwind CSS](https://tailwindcss.com/) for rapid styling.
+* **Pages**:
+  - `/` – Home / Hero section
+  - `/about` – About me information
+  - `/projects` – Portfolio projects gallery
+  - `/contact` – Contact details or form
+* **Components**:
+  - `Navbar` for site navigation
+  - `Footer` for basic footer content
+* **Future Work**: The design and content from Canva will be translated into React components and pages within this structure.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+   Then open [http://localhost:3000](http://localhost:3000) in your browser.
+
+This skeleton includes placeholder pages and components from which the full portfolio will be built.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "rohitha-portfolio",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.1.3",
+    "@types/react": "18.2.14",
+    "@types/node": "20.5.1",
+    "eslint": "8.45.0",
+    "eslint-config-next": "14.2.3",
+    "tailwindcss": "3.3.5",
+    "postcss": "8.4.24",
+    "autoprefixer": "10.4.15"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">About Me</h2>
+      <p>This page will contain information about Rohitha.</p>
+    </section>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function ContactPage() {
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">Contact</h2>
+      <p>You can reach me at <a href="mailto:example@example.com" className="underline">example@example.com</a>.</p>
+    </section>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-white text-gray-900;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="flex min-h-screen flex-col">
+        <Navbar />
+        <main className="flex-grow container mx-auto p-4">{children}</main>
+        <Footer />
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Rohitha's Portfolio</h1>
+      <p className="text-lg">Welcome to my portfolio site built with Next.js.</p>
+    </div>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,8 @@
+export default function ProjectsPage() {
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">Projects</h2>
+      <p>A gallery of my work will appear here.</p>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="bg-gray-100 p-4 text-center">
+      <p>&copy; {new Date().getFullYear()} Rohitha.</p>
+    </footer>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function Navbar() {
+  return (
+    <nav className="bg-gray-800 text-white p-4">
+      <ul className="flex space-x-4">
+        <li>
+          <Link href="/">Home</Link>
+        </li>
+        <li>
+          <Link href="/about">About</Link>
+        </li>
+        <li>
+          <Link href="/projects">Projects</Link>
+        </li>
+        <li>
+          <Link href="/contact">Contact</Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap Next.js + Tailwind CSS skeleton
- add placeholder pages (home, about, projects, contact)
- set up basic layout with navbar and footer
- document project plan and setup instructions

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68687c790b708320a63a7311647a23ba